### PR TITLE
add noLog4jDefaultConf parameter

### DIFF
--- a/bindings/java/src/org/hyperic/sigar/SigarLog.java
+++ b/bindings/java/src/org/hyperic/sigar/SigarLog.java
@@ -31,6 +31,8 @@ public class SigarLog {
     private static final int LOG_INFO   = 3;
     private static final int LOG_DEBUG  = 4;
 
+    private static final boolean enableLogFallbackConf = ! Boolean.getBoolean("sigar.noLog4jDefaultConfig");
+
     private static native void setLogger(Sigar sigar, Logger log);
 
     public static native void setLevel(Sigar sigar, int level);
@@ -48,7 +50,7 @@ public class SigarLog {
 
     public static Logger getLogger(String name) {
         Logger log = Logger.getLogger(name);
-        if (!isLogConfigured()) {
+        if (enableLogFallbackConf && !isLogConfigured()) {
             BasicConfigurator.configure();
         }
         return log;


### PR DESCRIPTION
Using log4j-over-slf4j instead of log4j raise an exception in the SigarLog class, because the function getAllAppenders is not implemented in the slf4j logger facade.

Our application is in charge of initializing the logging configuration.
As we don't have any usage for using BasicConfigurator as a fallback to initialize log4j, a system property allow us to skip the calls to log4j low level api in the SigarLog class.
