### PR TITLE
OSX removed gestalt

### DIFF
--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 
 #include "sigar.h"
+#include "sigar_util.h"
 #include "sigar_os.h"
 #include "lua-sigar.h"
 

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 
 #include "sigar.h"
+#include "sigar_os.h"
 #include "lua-sigar.h"
 
 /**

--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ case $host_os in
 esac
 AC_MSG_RESULT([$SRC_OS])
 
-AC_CHECK_HEADERS(libproc.h valgrind/valgrind.h)
+AC_CHECK_HEADERS(utmp.h utmpx.h libproc.h valgrind/valgrind.h)
 if test $ac_cv_header_libproc_h = yes; then
         AC_DEFINE(DARWIN_HAS_LIBPROC_H, [1], [sigar named them DARWIN_HAS_... instead of HAVE_])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 AC_CONFIG_MACRO_DIR([m4])
+m4_pattern_allow([^AC_DEFINE]) 
 
 AC_MSG_CHECKING([for os type ($host_os)])
 FRAMEWORK=

--- a/include/sigar_util.h
+++ b/include/sigar_util.h
@@ -17,6 +17,7 @@
 
 #ifndef SIGAR_UTIL_H
 #define SIGAR_UTIL_H
+#include "sigar_private.h"
 
 /* most of this is crap for dealing with linux /proc */
 #define UITOA_BUFFER_SIZE \

--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -50,8 +50,6 @@
 #endif
 #include <mach-o/dyld.h>
 #define __OPENTRANSPORTPROVIDERS__
-#include <Gestalt.h>
-#include <CFString.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOBSD.h>
 #include <IOKit/IOKitLib.h>
@@ -3605,44 +3603,86 @@ int sigar_proc_port_get(sigar_t *sigar, int protocol,
 
 #endif
 
+#ifdef DARWIN
+
+/**
+ * OSX Stores the current version in these two plist files:
+ *    /System/Library/CoreServices/ServerVersion.plist
+ *    /System/Library/CoreServices/SystemVersion.plist
+ *
+ * We use the private CoreFoundations methods used by `/usr/bin/sw_vers`
+ * to access the contents of these files.
+ */
+
+extern CFDictionaryRef _CFCopyServerVersionDictionary();
+extern CFDictionaryRef _CFCopySystemVersionDictionary();
+
+#ifndef _kCFSystemVersionProductNameKey
+#define _kCFSystemVersionProductNameKey "ProductName"
+#endif
+
+#ifndef _kCFSystemVersionProductVersionKey
+#define _kCFSystemVersionProductVersionKey "ProductVersion"
+#endif
+
+#ifndef _kCFSystemVersionBuildVersionKey
+#define _kCFSystemVersionBuildVersionKey "ProductBuildVersion"
+#endif
+
+#endif
+
 int sigar_os_sys_info_get(sigar_t *sigar,
                           sigar_sys_info_t *sysinfo)
 {
 #ifdef DARWIN
     char *codename = NULL;
-    SInt32 version, version_major, version_minor, version_fix;
+    CFDictionaryRef dict = NULL;
+    CFStringRef str = NULL;
+    char buf[256];
+    int version_major = 0;
+    int version_minor = 0;
+    int version_fix = 0;
+    int rv;
+
+    dict = _CFCopyServerVersionDictionary();
+
+    if (dict == NULL) {
+      dict = _CFCopySystemVersionDictionary();
+    }
+
+    if (dict == NULL) {
+      return SIGAR_EPROC_NOENT;
+    }
+
+    str = CFDictionaryGetValue(dict, _kCFSystemVersionProductNameKey);
+    CFStringGetCString(str, buf, sizeof(buf), kCFStringEncodingUTF8);
 
     SIGAR_SSTRCPY(sysinfo->name, "MacOSX");
+    SIGAR_SSTRCPY(sysinfo->vendor_name, buf);
+
+    CFDictionaryGetValue(dict, _kCFSystemVersionProductVersionKey),
+    CFStringGetCString(str, buf, sizeof(buf), kCFStringEncodingUTF8);
+
+    rv = sscanf(buf, "%d.%d.%d", &version_major, &version_minor, &version_fix);
+
+    CFRelease(dict);
+
+    if (rv != 3) {
+      return SIGAR_EPERM_KMEM;
+    }
+
     SIGAR_SSTRCPY(sysinfo->vendor_name, "Mac OS X");
     SIGAR_SSTRCPY(sysinfo->vendor, "Apple");
-
-    if (Gestalt(gestaltSystemVersion, &version) == noErr) {
-        if (version >= 0x00001040) {
-            Gestalt('sys1' /*gestaltSystemVersionMajor*/, &version_major);
-            Gestalt('sys2' /*gestaltSystemVersionMinor*/, &version_minor);
-            Gestalt('sys3' /*gestaltSystemVersionBugFix*/, &version_fix);
-        }
-        else {
-            version_fix = version & 0xf;
-            version >>= 4;
-            version_minor = version & 0xf;
-            version >>= 4;
-            version_major = version - (version >> 4) * 6;
-        }
-    }
-    else {
-        return SIGAR_ENOTIMPL;
-    }
 
     snprintf(sysinfo->vendor_version,
              sizeof(sysinfo->vendor_version),
              "%d.%d",
-             (int)version_major, (int)version_minor);
+             version_major, version_minor);
 
     snprintf(sysinfo->version,
              sizeof(sysinfo->version),
              "%s.%d",
-             sysinfo->vendor_version, (int)version_fix);
+             sysinfo->vendor_version, version_fix);
 
     if (version_major == 10) {
         switch (version_minor) {
@@ -3663,6 +3703,9 @@ int sigar_os_sys_info_get(sigar_t *sigar,
             break;
           case 7:
             codename = "Lion";
+            break;
+          case 8:
+            codename = "Mountain Lion";
             break;
           default:
             codename = "Unknown";

--- a/src/sigar.c
+++ b/src/sigar.c
@@ -30,6 +30,11 @@
 #ifndef WIN32
 #include <arpa/inet.h>
 #endif
+#if defined(HAVE_UTMPX_H)
+# include <utmpx.h>
+#elif defined(HAVE_UTMP_H)
+# include <utmp.h>
+#endif
 
 #include "sigar.h"
 #include "sigar_private.h"
@@ -1024,40 +1029,7 @@ SIGAR_DECLARE(int) sigar_who_list_destroy(sigar_t *sigar,
     return SIGAR_OK;
 }
 
-#ifdef DARWIN
-#include <AvailabilityMacros.h>
-#endif
-#ifdef MAC_OS_X_VERSION_10_5
-#  if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5
-#    define SIGAR_NO_UTMP
-#  endif
-/* else 10.4 and earlier or compiled with -mmacosx-version-min=10.3 */
-#endif
-
-#if defined(__sun)
-#  include <utmpx.h>
-#  define SIGAR_UTMP_FILE _UTMPX_FILE
-#  define ut_time ut_tv.tv_sec
-#elif defined(WIN32)
-/* XXX may not be the default */
-#define SIGAR_UTMP_FILE "C:\\cygwin\\var\\run\\utmp"
-#define UT_LINESIZE	16
-#define UT_NAMESIZE	16
-#define UT_HOSTSIZE	256
-#define UT_IDLEN	2
-#define ut_name ut_user
-
-struct utmp {
-    short ut_type;	
-    int ut_pid;		
-    char ut_line[UT_LINESIZE];
-    char ut_id[UT_IDLEN];
-    time_t ut_time;	
-    char ut_user[UT_NAMESIZE];	
-    char ut_host[UT_HOSTSIZE];	
-    long ut_addr;	
-};
-#elif defined(NETWARE)
+#if defined(NETWARE)
 static char *getpass(const char *prompt)
 {
     static char password[BUFSIZ];
@@ -1067,109 +1039,48 @@ static char *getpass(const char *prompt)
 
     return (char *)&password;
 }
-#elif !defined(SIGAR_NO_UTMP)
-#  include <utmp.h>
-#  ifdef UTMP_FILE
-#    define SIGAR_UTMP_FILE UTMP_FILE
-#  else
-#    define SIGAR_UTMP_FILE _PATH_UTMP
-#  endif
 #endif
-
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(DARWIN)
-#  define ut_user ut_name
-#endif
-
-#ifdef DARWIN
-/* XXX from utmpx.h; sizeof changed in 10.5 */
-/* additionally, utmpx does not work on 10.4 */
-#define SIGAR_HAS_UTMPX
-#define _PATH_UTMPX     "/var/run/utmpx"
-#define _UTX_USERSIZE   256     /* matches MAXLOGNAME */
-#define _UTX_LINESIZE   32
-#define _UTX_IDSIZE     4
-#define _UTX_HOSTSIZE   256
-struct utmpx {
-    char ut_user[_UTX_USERSIZE];    /* login name */
-    char ut_id[_UTX_IDSIZE];        /* id */
-    char ut_line[_UTX_LINESIZE];    /* tty name */
-    pid_t ut_pid;                   /* process id creating the entry */
-    short ut_type;                  /* type of this entry */
-    struct timeval ut_tv;           /* time entry was created */
-    char ut_host[_UTX_HOSTSIZE];    /* host name */
-    __uint32_t ut_pad[16];          /* reserved for future use */
-};
-#define ut_xtime ut_tv.tv_sec
-#define UTMPX_USER_PROCESS      7
-/* end utmpx.h */
-#define SIGAR_UTMPX_FILE _PATH_UTMPX
-#endif
-
-#if !defined(NETWARE) && !defined(_AIX)
 
 #define WHOCPY(dest, src) \
     SIGAR_SSTRCPY(dest, src); \
     if (sizeof(src) < sizeof(dest)) \
         dest[sizeof(src)] = '\0'
 
-#ifdef SIGAR_HAS_UTMPX
-static int sigar_who_utmpx(sigar_t *sigar,
-                           sigar_who_list_t *wholist)
+static int sigar_who_utmp(sigar_t *sigar,
+                          sigar_who_list_t *wholist)
 {
-    FILE *fp;
-    struct utmpx ut;
+#if defined(HAVE_UTMPX_H)
+    struct utmpx *ut;
 
-    if (!(fp = fopen(SIGAR_UTMPX_FILE, "r"))) {
-        return errno;
-    }
+    setutxent();
 
-    while (fread(&ut, sizeof(ut), 1, fp) == 1) {
+    while ((ut = getutxent()) != NULL) {
         sigar_who_t *who;
 
-        if (*ut.ut_user == '\0') {
+        if (*ut->ut_user == '\0') {
             continue;
         }
 
-#ifdef UTMPX_USER_PROCESS
-        if (ut.ut_type != UTMPX_USER_PROCESS) {
+        if (ut->ut_type != USER_PROCESS) {
             continue;
         }
-#endif
 
         SIGAR_WHO_LIST_GROW(wholist);
         who = &wholist->data[wholist->number++];
 
-        WHOCPY(who->user, ut.ut_user);
-        WHOCPY(who->device, ut.ut_line);
-        WHOCPY(who->host, ut.ut_host);
+        WHOCPY(who->user, ut->ut_user);
+        WHOCPY(who->device, ut->ut_line);
+        WHOCPY(who->host, ut->ut_host);
 
-        who->time = ut.ut_xtime;
+        who->time = ut->ut_tv.tv_sec;
     }
 
-    fclose(fp);
-
-    return SIGAR_OK;
-}
-#endif
-
-#if defined(SIGAR_NO_UTMP) && defined(SIGAR_HAS_UTMPX)
-#define sigar_who_utmp sigar_who_utmpx
-#else
-static int sigar_who_utmp(sigar_t *sigar,
-                          sigar_who_list_t *wholist)
-{
+    endutxent();
+#elif defined(HAVE_UTMP_H)
     FILE *fp;
-#ifdef __sun
-    /* use futmpx w/ pid32_t for sparc64 */
-    struct futmpx ut;
-#else
     struct utmp ut;
-#endif
-    if (!(fp = fopen(SIGAR_UTMP_FILE, "r"))) {
-#ifdef SIGAR_HAS_UTMPX
-        /* Darwin 10.5 */
-        return sigar_who_utmpx(sigar, wholist);
-#endif
+
+    if (!(fp = fopen(_PATH_UTMP, "r"))) {
         return errno;
     }
 
@@ -1189,7 +1100,7 @@ static int sigar_who_utmp(sigar_t *sigar,
         SIGAR_WHO_LIST_GROW(wholist);
         who = &wholist->data[wholist->number++];
 
-        WHOCPY(who->user, ut.ut_user);
+        WHOCPY(who->user, ut.ut_name);
         WHOCPY(who->device, ut.ut_line);
         WHOCPY(who->host, ut.ut_host);
 
@@ -1197,11 +1108,10 @@ static int sigar_who_utmp(sigar_t *sigar,
     }
 
     fclose(fp);
+#endif
 
     return SIGAR_OK;
 }
-#endif /* SIGAR_NO_UTMP */
-#endif /* NETWARE */
 
 #if defined(WIN32)
 


### PR DESCRIPTION
- `Gestalt` was removed from public headers, so I switched to using the plist files that have the current version.
- Add support for OSX 10.8 / Mountain Lion version name.
