### PR TITLE
Bypass ifr_hw stuff on solaris, issue-27

### DIFF
--- a/src/sigar.c
+++ b/src/sigar.c
@@ -1731,7 +1731,7 @@ int sigar_net_interface_config_get(sigar_t *sigar, const char *name,
                                   ifr_s_addr(ifr));
         }
 
-#if defined(SIOCGIFHWADDR)
+#if defined(SIOCGIFHWADDR) && !defined(__sun__)
         if (!ioctl(sock, SIOCGIFHWADDR, &ifr)) {
             get_interface_type(ifconfig,
                                ifr.ifr_hwaddr.sa_family);


### PR DESCRIPTION
Just trying to do something about #27.
It compiled, but now a memory test fails:

rake/gempackagetask is deprecated.  Use rubygems/package_task instead
make: Nothing to be done for `all'.
Run options:
# Running tests:

...F..

Finished tests in 0.016024s, 374.4379 tests/s, 11108.3250 assertions/s.

  1) Failure:
test_mem(MemTest) [/root/sigar_killfill/bindings/ruby/test/mem_test.rb:28]:
<-556.0889720916748> is not > 0.

6 tests, 178 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [/opt/local/bin/ruby193 -I"lib:." -I"/opt/l...]

Tasks: TOP => default => test
(See full trace by running task with --trace)
