### PR TITLE
Don't inline when compiling with Clang

### DIFF
--- a/include/sigar_private.h
+++ b/include/sigar_private.h
@@ -73,7 +73,7 @@
 
 #if defined(WIN32)
 #   define SIGAR_INLINE __inline
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(__clang__)
 #   define SIGAR_INLINE inline
 #else
 #   define SIGAR_INLINE


### PR DESCRIPTION
Clang has a different behaviour than GCC when it comes to inlining functions.
Sadly Clang identifies itself as **GNUC**, hence the define to prevent non-GCC
compilers to use the inline keyword didn't work.

This commit solves the problem with adding an additional check to the define,
that the compiler isn't Clang.

During compilation you get warnings like:

```
In file included from linux_sigar.c:30:
../../../include/sigar_util.h:80:20: warning: inline function 'sigar_skip_token' is not defined
      [-Wundefined-inline]
SIGAR_INLINE char *sigar_skip_token(char *p);
               ^
linux_sigar.c:137:24: note: used here
            if ((ptr = sigar_skip_token(ptr))) {
                       ^
```

Which end up in an error like:

```
libtool: link: clang -g -O2 -o .libs/cpuinfo cpuinfo.o  ../src/.libs/libsigar.so
../src/.libs/libsigar.so: undefined reference to `sigar_skip_token'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
