### PR TITLE
Fix build on OSX 10.10

### DIFF
--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -16,6 +16,12 @@
  * limitations under the License.
  */
 
+#ifdef DARWIN
+#include <sys/socket.h>
+#include <sys/fcntl.h>
+#include <mach/thread_info.h>
+#endif
+
 #include "sigar.h"
 #include "sigar_private.h"
 #include "sigar_util.h"
@@ -38,7 +44,6 @@
 #include <mach/mach_port.h>
 #include <mach/task.h>
 #include <mach/thread_act.h>
-#include <mach/thread_info.h>
 #include <mach/vm_map.h>
 #if !defined(HAVE_SHARED_REGION_H) && defined(__MAC_10_5) /* see Availability.h */
 #  define HAVE_SHARED_REGION_H /* suckit autoconf */


### PR DESCRIPTION
Clang adheres to the letter of C99 wherein functions must be declared first before usage. Unfortunately, it seems that the nfs/nfs_*.h headers in OSX 10.10 do not include the necessary headers required for the routines it uses from the following headers:

* sys/fcntl.h
* sys/socket.h
* mach/thread_info.h

Instead of patching the SDK headers, this patch just includes the said headers for src/os/darwin/darwin_sigar.c to build.