### PR TITLE
should fix #47

### DIFF
--- a/bindings/ruby/extconf.rb
+++ b/bindings/ruby/extconf.rb
@@ -31,6 +31,12 @@ when /darwin/
   end
   $CPPFLAGS += ' -DDARWIN'
   $LDFLAGS += ' -framework CoreServices -framework IOKit'
+
+  # only for Yosemite
+  if ENV['_system_version'] =~ /\A10\.10/
+    cc = ENV['CC'] || %x(which clang).chop
+    CONFIG['CC']= cc
+  end
 when /bsd/
   os = 'darwin'
   have_library("kvm")


### PR DESCRIPTION
Hey,

as I was unable to install any version of sigar to my OSX Yosemite so I think this should fix it. The problem is that any gcc can't compile objC code - and right after changing default gcc to clang, it works and clearly installs sigar under 10.10.1. It allows to specify CC when installing, like `CC=/usr/local/bin/clang gem install sigar`