### PR TITLE
Fix MIB_IPADDRROW.wType for MinGW w64

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ IF(WIN32)
   ADD_DEFINITIONS(-DSIGAR_SHARED)
   SET(SIGAR_SRC os/win32/peb.c os/win32/win32_sigar.c)
   INCLUDE_DIRECTORIES(os/win32)
-  CHECK_STRUCT_MEMBER(MIB_IPADDRROW wType "windows.h;iphlpapi.h" wType_in_MIB_IPADDRROW)
+  CHECK_STRUCT_MEMBER(MIB_IPADDRROW wType "winsock2.h;windows.h;iphlpapi.h" wType_in_MIB_IPADDRROW)
   add_definitions(-DHAVE_MIB_IPADDRROW_WTYPE=${wType_in_MIB_IPADDRROW})
 ENDIF(WIN32)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,28 +4,7 @@ MESSAGE(STATUS "CMAKE_SYSTEM_NAME is ${CMAKE_SYSTEM_NAME}")
 
 INCLUDE_DIRECTORIES(../include/)
 
-INCLUDE(CheckCSourceCompiles)
-
-MACRO (CHECK_STRUCT_MEMBER _STRUCT _MEMBER _HEADER _RESULT)
-   SET(_INCLUDE_FILES)
-   FOREACH (it ${_HEADER})
-      SET(_INCLUDE_FILES "${_INCLUDE_FILES}#include <${it}>\n")
-   ENDFOREACH (it)
-
-   SET(_CHECK_STRUCT_MEMBER_SOURCE_CODE "
-${_INCLUDE_FILES}
-int main()
-{
-   static ${_STRUCT} tmp;
-   if (sizeof(tmp.${_MEMBER}))
-      return 0;
-  return 0;
-}
-")
-   CHECK_C_SOURCE_COMPILES("${_CHECK_STRUCT_MEMBER_SOURCE_CODE}" ${_RESULT})
-
-ENDMACRO (CHECK_STRUCT_MEMBER)
-
+INCLUDE(CheckStructHasMember)
 
 ## linux
 IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -82,7 +61,7 @@ IF(WIN32)
   ADD_DEFINITIONS(-DSIGAR_SHARED)
   SET(SIGAR_SRC os/win32/peb.c os/win32/win32_sigar.c)
   INCLUDE_DIRECTORIES(os/win32)
-  CHECK_STRUCT_MEMBER(MIB_IPADDRROW wType "winsock2.h;windows.h;iphlpapi.h" wType_in_MIB_IPADDRROW)
+  CHECK_STRUCT_HAS_MEMBER(MIB_IPADDRROW wType "winsock2.h;windows.h;iphlpapi.h" wType_in_MIB_IPADDRROW)
   add_definitions(-DHAVE_MIB_IPADDRROW_WTYPE=${wType_in_MIB_IPADDRROW})
 ENDIF(WIN32)
 


### PR DESCRIPTION
Sigar's test for whether the `MIB_IPADDRROW` structure has a member named "`wType`" (as would be the case on Windows XP and later [[1]](https://msdn.microsoft.com/en-us/library/windows/desktop/aa366845%28v=vs.85%29.aspx)) fails when using MinGW-W64 4.9.1 (included with the latest version of Qt: 5.4 at time of writing). In September 2014, an "invalid version guard" was removed from `netioapi.h` (included by `iphlpapi.h`) [[2]](http://sourceforge.net/p/mingw-w64/mingw-w64/ci/b2aa85ca326ca55a2965da168c3c2d1c508c5572/)[[3]](http://sourceforge.net/p/mingw-w64/mailman/message/32871176/), which caused the inclusion of declarations that reference types like `ADDRESS_FAMILY` and `SOCKADDR_STORAGE` that are not present unless `winsock2.h` is included. To work around this issue, we include winsock2.h in our check program.

Including `winsock2.h` should have no effect on the test when using MSVC (tested with VS2010, and with VS2014 via webcompiler.cloudapp.net). In fact, Microsoft's documentation states that "The Winsock2.h header file for Windows Sockets 2.0 is required by most applications using the IP Helper APIs" [[4]](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365872%28v=vs.85%29.aspx). This issue with MinGW W64 has been reported elsewhere [[5]](http://stackoverflow.com/questions/29069904/why-does-mingw-w64-require-winsock2-to-be-manually-included), and a similar workaround was added to the Ruby trunk to work around it [[6]](https://bugs.ruby-lang.org/issues/10640)[[7]](https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/48997). In the meantime, adding this header should cause no harm, and seems a reasonable thing to do.

Also included in this pull request is a refactor of `CMakeLists.txt` to use the CMake-provided function for checking if a struct has a desired member, instead of rolling our own. The module (`CheckStructHasMember`) has been around since CMake 2.6 [[8]](http://www.cmake.org/Wiki/CMake_Version_Compatibility_Matrix/StandardCMakeModulesA), the current minimum required version in the top-level CMakeLists.txt.

[1] https://msdn.microsoft.com/en-us/library/windows/desktop/aa366845%28v=vs.85%29.aspx
[2] http://sourceforge.net/p/mingw-w64/mingw-w64/ci/b2aa85ca326ca55a2965da168c3c2d1c508c5572/
[3] http://sourceforge.net/p/mingw-w64/mailman/message/32871176/
[4] https://msdn.microsoft.com/en-us/library/windows/desktop/aa365872%28v=vs.85%29.aspx
[5] http://stackoverflow.com/questions/29069904/why-does-mingw-w64-require-winsock2-to-be-manually-included
[6] https://bugs.ruby-lang.org/issues/10640
[7] https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/48997
[8] http://www.cmake.org/Wiki/CMake_Version_Compatibility_Matrix/StandardCMakeModulesA
