### PR TITLE
build and load 32 bit program and library on hpux ia64 platform

### DIFF
--- a/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchName.java
+++ b/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchName.java
@@ -62,7 +62,10 @@ public class ArchName {
         }
         else if (name.equals("HP-UX")) {
             if (arch.startsWith("IA64")) {
-                arch = "ia64";
+                arch = "ia";
+                if (is64()) {
+                    arch += "64";
+                }
             }
             else {
                 arch = "pa";


### PR DESCRIPTION
although the arch is IA64,but 32bit could run on the platform. 
And sometimes a 32bit sigar library is needed, specially  java run in default 32 bit mode.