### PR TITLE
modify build xml file and  ArchName.java

### DIFF
--- a/bindings/java/hyperic_jni/jni-build.xml
+++ b/bindings/java/hyperic_jni/jni-build.xml
@@ -270,8 +270,9 @@
 	relentless="false">
 
       <!-- HPUX -->
-      <compiler name="hp"  if="hpux">
+      <compiler name="aCC"  if="hpux">
         <compilerarg value="+Z"/>
+        <compilerarg value="-Ae"/>
         <compilerarg value="+DD64" if="jni.arch64"/>
 
         <defineset>
@@ -281,7 +282,8 @@
         </defineset>
       </compiler>
 
-      <linker name="hp" if="hpux">
+      <linker name="aCC" if="hpux">
+      	<linkerarg value="+DD64" if="jni.arch64"/>
         <libset if="jni.libset.libs"
                 dir="${jni.libset.dir}"
                 libs="${jni.libset.libs}"/>
@@ -437,7 +439,7 @@
       </linker>
 
       <!-- AIX -->
-      <compiler name="xlc_r" if="aix">
+      <compiler name="xlC" if="aix">
         <compilerarg value="-q64" if="jni.arch64"/>
         <defineset>
           <define name="${jni.define.name}_AIX"/>
@@ -447,7 +449,7 @@
         </defineset>
       </compiler>
 
-      <linker name="xlc_r" if="aix">
+      <linker name="xlC" if="aix">
         <linkerarg value="-b64" if="jni.arch64"/>
         <libset if="jni.libset.libs"
                 dir="${jni.libset.dir}"

--- a/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchName.java
+++ b/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchName.java
@@ -62,7 +62,10 @@ public class ArchName {
         }
         else if (name.equals("HP-UX")) {
             if (arch.startsWith("IA64")) {
-                arch = "ia64";
+                arch = "ia";
+                if (is64()) {
+                    arch += "64";
+                }
             }
             else {
                 arch = "pa";


### PR DESCRIPTION
Build and load 32 bit program and library on hpux ia64 platform .
Although the arch is IA64,but 32bit could run on the platform.

Modify compiler name and linker name,refer http://ant-contrib.sourceforge.net/cpptasks/antdocs/CompilerDef.html and http://ant-contrib.sourceforge.net/cpptasks/antdocs/LinkerDef.html. Add the -Ae argument for aCC compiling C language. Add the +DD64 option for aCC linking 64bit library, refer http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/Online_Help/options.htm