### PR TITLE
Remove use of v_cache_min/max

### DIFF
--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -400,8 +400,10 @@ static int sigar_vmstat(sigar_t *sigar, struct vmmeter *vmstat)
     GET_VM_STATS(vm, v_inactive_target, 0);
     GET_VM_STATS(vm, v_inactive_count, 1);
     GET_VM_STATS(vm, v_cache_count, 1);
+#if (__FreeBSD_version < 1100079 )
     GET_VM_STATS(vm, v_cache_min, 0);
     GET_VM_STATS(vm, v_cache_max, 0);
+#endif
     GET_VM_STATS(vm, v_pageout_free_min, 0);
     GET_VM_STATS(vm, v_interrupt_free_min, 0);
     GET_VM_STATS(vm, v_forks, 0);


### PR DESCRIPTION
These were removed in svn r287640 (aka freebsd/freebsd@3411676 ) but no __FreeBSD_version bump was done specifically for it, so use the closest one. This fixes build on FreeBSD 11-CURRENT and newer (will become FreeBSD 11.0)
