### PR TITLE
ruby: fix sporadic segfaults during the garbage collection

### DIFF
--- a/bindings/ruby/rbsigar.c
+++ b/bindings/ruby/rbsigar.c
@@ -162,6 +162,7 @@ static VALUE rb_sigar_new(VALUE module)
 {
     rb_sigar_t *rbsigar;
     rbsigar = ALLOC(rb_sigar_t);
+    rbsigar->logger = Qnil;
     sigar_open(&(rbsigar->sigar));
     return Data_Wrap_Struct(module, rb_sigar_mark, rb_sigar_close, rbsigar);
 }


### PR DESCRIPTION
rb_sigar_new does not initialize rb_sigar_t->logger, as a result ruby
runtime garbage collection routines sometimes fail either with a segfault
or an assertion failure:

$ cat test2.rb

 require 'sigar'
 100.times do
   GC.disable
   sigars = []
   100.times do
     sigar = Sigar.new
     sigars << sigar
   end
   GC.enable
   GC.start
   sleep 2
 end

$ ruby test2.rb
/home/asheplyakov/tmp/test2.rb:11: [BUG] rb_gc_mark(): unknown data type 0x0(0x7fbff5cc07c8) non object
ruby 1.9.3p484 (2013-11-22 revision 43786) [x86_64-linux]
[skipped]

Initialize rb_sigar_t->logger to avoid the problem.

Fixes github issue #79
