### PR TITLE
Fix off by one bug when more data is read than buflen

### DIFF
--- a/src/sigar_util.c
+++ b/src/sigar_util.c
@@ -838,7 +838,7 @@ int sigar_file2str(const char *fname, char *buffer, int buflen)
         return ENOENT;
     }
 
-    if ((len = read(fd, buffer, buflen)) < 0) {
+    if ((len = read(fd, buffer, buflen - 1)) < 0) {
         status = errno;
     }
     else {


### PR DESCRIPTION
This bug was discovered when /proc/stat (on a larger 56 core box) exceeded BUFSIZ=8192,
coming from codepath sigar_cpu_get(), causing a \0 to be written
one byte outside what was allocated, causing a segfault.
