### PR TITLE
get_iostat_sys fsdev traversal fix

### DIFF
--- a/bindings/lua/sigar-cpu.c
+++ b/bindings/lua/sigar-cpu.c
@@ -161,11 +161,23 @@ static int lua_sigar_cpus_len(lua_State *L) {
 int lua_sigar_cpus_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	lua_sigar_cpus_t *cpus;
+  int rc;
 
 	cpus = lua_newuserdata(L, sizeof(lua_sigar_cpus_t));
 	cpus->sigar = s;
-	sigar_cpu_list_get(s, &(cpus->data));
-	sigar_cpu_info_list_get(s, &(cpus->info));
+
+	rc = sigar_cpu_list_get(s, &(cpus->data));
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_cpu_list_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
+	rc = sigar_cpu_info_list_get(s, &(cpus->info));
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_cpu_info_list_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
 	cpus->ref_count = 1;
 	if (0 != luaL_newmetatable(L, "sigar_cpus")) {
 		lua_pushcfunction(L, lua_sigar_cpus_len);

--- a/bindings/lua/sigar-disk.c
+++ b/bindings/lua/sigar-disk.c
@@ -148,7 +148,7 @@ static int lua_sigar_disks_get_disk(lua_State *L) {
 	}
 
 	disk = lua_newuserdata(L, sizeof(*disk));
-	disk->dev_name = strdup(disks->disks.data[ndx - 1].dir_name);
+	disk->dev_name = strdup(disks->disks.data[ndx - 1].dev_name);
 	disk->sigar = disks->sigar;
 	lua_sigar_disk_set_metatable(L, -1);
 

--- a/bindings/lua/sigar-disk.c
+++ b/bindings/lua/sigar-disk.c
@@ -172,10 +172,17 @@ int lua_sigar_disk_get(lua_State *L) {
 int lua_sigar_disks_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	lua_sigar_disks_t *disks;
+  int rc;
 
 	disks = lua_newuserdata(L, sizeof(lua_sigar_disks_t));
 	disks->sigar = s;
-	sigar_file_system_list_get(s, &(disks->disks));
+
+	rc = sigar_file_system_list_get(s, &(disks->disks));
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_file_system_list_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
 	disks->ref_count = 1;
 	if (0 != luaL_newmetatable(L, "sigar_disks")) {
 		lua_pushcfunction(L, lua_sigar_disks_len);

--- a/bindings/lua/sigar-fs.c
+++ b/bindings/lua/sigar-fs.c
@@ -166,10 +166,17 @@ static int lua_sigar_fses_get_fs(lua_State *L) {
 int lua_sigar_fses_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	lua_sigar_fses_t *fses;
+  int rc;
 
 	fses = lua_newuserdata(L, sizeof(lua_sigar_fses_t));
 	fses->sigar = s;
-	sigar_file_system_list_get(s, &(fses->fses));
+
+	rc = sigar_file_system_list_get(s, &(fses->fses));
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_file_system_list_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
 	fses->ref_count = 1;
 	if (0 != luaL_newmetatable(L, "sigar_fses")) {
 		lua_pushcfunction(L, lua_sigar_fses_len);

--- a/bindings/lua/sigar-load.c
+++ b/bindings/lua/sigar-load.c
@@ -50,10 +50,10 @@ int lua_sigar_load_get(lua_State *L) {
 	lua_newtable(L);
 
 	lua_pushnumber(L, load.loadavg[0]);
-	lua_setfield(L, -2, "5m");
+	lua_setfield(L, -2, "1m");
 
 	lua_pushnumber(L, load.loadavg[1]);
-	lua_setfield(L, -2, "10m");
+	lua_setfield(L, -2, "5m");
 
 	lua_pushnumber(L, load.loadavg[2]);
 	lua_setfield(L, -2, "15m");

--- a/bindings/lua/sigar-load.c
+++ b/bindings/lua/sigar-load.c
@@ -43,7 +43,7 @@ int lua_sigar_load_get(lua_State *L) {
 	rc = sigar_loadavg_get(s, &load);
 
   if (rc != 0) {
-    luaL_error(L, "load average error: %s", sigar_strerror(s, rc));
+    luaL_error(L, "sigar_loadavg_get error: %s", sigar_strerror(s, rc));
     return 0;
   }
 

--- a/bindings/lua/sigar-mem.c
+++ b/bindings/lua/sigar-mem.c
@@ -38,8 +38,13 @@
 int lua_sigar_mem_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	sigar_mem_t mem;
+  int rc;
 
-	sigar_mem_get(s, &mem);
+	rc = sigar_mem_get(s, &mem);
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_mem_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
 
 	lua_newtable(L);
 #define DATA \

--- a/bindings/lua/sigar-netif.c
+++ b/bindings/lua/sigar-netif.c
@@ -98,6 +98,9 @@ static int lua_sigar_netif_get_info(lua_State *L) {
 #define DATA \
 	(&(usage))
 
+	if (usage.address6.family == SIGAR_AF_INET6) {
+		LUA_EXPORT_ADDRESS(DATA, address6);
+	}
 	LUA_EXPORT_STR(DATA, name);
 	LUA_EXPORT_STR(DATA, type);
 	LUA_EXPORT_ADDRESS(DATA, hwaddr);

--- a/bindings/lua/sigar-netif.c
+++ b/bindings/lua/sigar-netif.c
@@ -188,10 +188,18 @@ static int lua_sigar_netifs_get_netif(lua_State *L) {
 int lua_sigar_netifs_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	lua_sigar_netifs_t *netifs;
+  int rc;
 
 	netifs = lua_newuserdata(L, sizeof(lua_sigar_netifs_t));
 	netifs->sigar = s;
-	sigar_net_interface_list_get(s, &(netifs->netifs));
+
+	rc = sigar_net_interface_list_get(s, &(netifs->netifs));
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_net_interface_list_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
+
 	netifs->ref_count = 1;
 	if (0 != luaL_newmetatable(L, "sigar_netifs")) {
 		lua_pushcfunction(L, lua_sigar_netifs_len);

--- a/bindings/lua/sigar-proc.c
+++ b/bindings/lua/sigar-proc.c
@@ -61,7 +61,7 @@ static int lua_sigar_procs_get_pid(lua_State *L) {
 	lua_sigar_procs_t *procs = (lua_sigar_procs_t *)luaL_checkudata(L, 1, "sigar_procs");
 	int ndx = luaL_checkint(L, 2);
 
-	if (ndx - 1 < 0 || 
+	if (ndx - 1 < 0 ||
 	    ndx - 1 >= procs->procs.number) {
 		luaL_error(L, ".procs[%d] out of range: 1..%d", ndx, procs->procs.number);
 	}
@@ -103,6 +103,29 @@ static int lua_sigar_proc_gc(lua_State *L) {
 	return 0;
 }
 
+static int lua_sigar_proc_get_cred(lua_State *L){
+	lua_sigar_proc_t *proc = (lua_sigar_proc_t *)luaL_checkudata(L, 1, "sigar_proc");
+	sigar_proc_cred_name_t cred;
+	int err;
+
+	if (SIGAR_OK != (err = sigar_proc_cred_name_get(proc->sigar, proc->pid, &cred))) {
+		lua_pushnil(L);
+		lua_pushstring(L, strerror(err));
+
+		return 2;
+	}
+
+	lua_newtable(L);
+#define DATA \
+	(&(cred))
+
+	LUA_EXPORT_STR(DATA, user);
+	LUA_EXPORT_STR(DATA, group);
+
+#undef DATA
+
+	return 1;
+}
 static int lua_sigar_proc_get_mem(lua_State *L) {
 	lua_sigar_proc_t *proc = (lua_sigar_proc_t *)luaL_checkudata(L, 1, "sigar_proc");
 	sigar_proc_mem_t mem;
@@ -199,6 +222,7 @@ static int lua_sigar_proc_get_exe(lua_State *L) {
 #define DATA \
 	(&(t))
 
+
 	LUA_EXPORT_STR(DATA, name);
 	LUA_EXPORT_STR(DATA, cwd);
 	LUA_EXPORT_STR(DATA, root);
@@ -220,6 +244,8 @@ int lua_sigar_proc_get(lua_State *L) {
 		lua_newtable(L);
 		lua_pushcfunction(L, lua_sigar_proc_get_mem);
 		lua_setfield(L, -2, "mem");
+		lua_pushcfunction(L, lua_sigar_proc_get_cred);
+		lua_setfield(L, -2, "cred");
 		lua_pushcfunction(L, lua_sigar_proc_get_time);
 		lua_setfield(L, -2, "time");
 		lua_pushcfunction(L, lua_sigar_proc_get_exe);

--- a/bindings/lua/sigar-proc.c
+++ b/bindings/lua/sigar-proc.c
@@ -74,10 +74,17 @@ static int lua_sigar_procs_get_pid(lua_State *L) {
 int lua_sigar_procs_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	lua_sigar_procs_t *procs;
+  int rc;
 
 	procs = lua_newuserdata(L, sizeof(lua_sigar_procs_t));
 	procs->sigar = s;
-	sigar_proc_list_get(s, &(procs->procs));
+
+	rc = sigar_proc_list_get(s, &(procs->procs));
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_proc_list_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
 	if (0 != luaL_newmetatable(L, "sigar_procs")) {
 		lua_pushcfunction(L, lua_sigar_procs_len);
 		lua_setfield(L, -2, "__len");

--- a/bindings/lua/sigar-swap.c
+++ b/bindings/lua/sigar-swap.c
@@ -38,8 +38,13 @@
 int lua_sigar_swap_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	sigar_swap_t swap;
+  int rc;
 
-	sigar_swap_get(s, &swap);
+	rc = sigar_swap_get(s, &swap);
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_swap_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
 
 	lua_newtable(L);
 #define DATA \

--- a/bindings/lua/sigar-sysinfo.c
+++ b/bindings/lua/sigar-sysinfo.c
@@ -39,8 +39,14 @@
 int lua_sigar_sysinfo_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	sigar_sys_info_t sysinfo;
+  int rc;
 
-	sigar_sys_info_get(s, &sysinfo);
+	rc = sigar_sys_info_get(s, &sysinfo);
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_sys_info_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
 
 	lua_newtable(L);
 #define DATA \

--- a/bindings/lua/sigar-who.c
+++ b/bindings/lua/sigar-who.c
@@ -83,10 +83,17 @@ static int lua_sigar_who_get_who(lua_State *L) {
 int lua_sigar_who_get(lua_State *L) {
 	sigar_t *s = *(sigar_t **)luaL_checkudata(L, 1, "sigar");
 	lua_sigar_who_t *who;
+  int rc;
 
 	who = lua_newuserdata(L, sizeof(lua_sigar_who_t));
 	who->sigar = s;
-	sigar_who_list_get(s, &(who->who));
+
+	rc = sigar_who_list_get(s, &(who->who));
+	if (rc != SIGAR_OK) {
+    luaL_error(L, "sigar_sys_info_get error: %s", sigar_strerror(s, rc));
+    return 0;
+  }
+
 	if (0 != luaL_newmetatable(L, "sigar_who")) {
 		lua_pushcfunction(L, lua_sigar_who_len);
 		lua_setfield(L, -2, "__len");

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 
 #include "sigar.h"
+#include "sigar_util.h"
 #include "sigar_os.h"
 #include "lua-sigar.h"
 

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -42,10 +42,7 @@
  * push the converted sigar_net_address_t as string on the stack
  */
 int lua_sigar_push_address(lua_State *L, sigar_net_address_t *addr) {
-	char s[24 + 1]; /* AF_LINK  is 2 * 8 + 7 colons = 23
-			   AF_INET6 is 4 * 4 + 3 colons = 17
-			   AF_INET  is 4 * 3 + 3 dots = 15
-			   */
+	char s[SIGAR_INET6_ADDRSTRLEN + 1];
 	size_t s_have = sizeof(s) - 1;
 	size_t s_need;
 
@@ -61,17 +58,7 @@ int lua_sigar_push_address(lua_State *L, sigar_net_address_t *addr) {
 				(addr->addr.in >> 24) & 0xff);
 		return 1;
 	case SIGAR_AF_INET6:
-		s_need = snprintf(s, s_have, "%4x:%4x:%4x:%4x",
-				(addr->addr.in6[0]),
-				(addr->addr.in6[1]),
-				(addr->addr.in6[2]),
-				(addr->addr.in6[3]));
-
-		if (s_need > s_have) {
-			/* string is truncated, but written to s */
-			luaL_error(L, "can't convert INET6 address string, not enough memory: %d need, %d available",
-					s_need, s_have);
-		}
+		inet_ntop(AF_INET6, &addr->addr.in6, s, INET6_ADDRSTRLEN);
 		lua_pushstring(L, s);
 		return 1;
 	case SIGAR_AF_LINK:

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -36,6 +36,10 @@
 #include "sigar.h"
 #include "lua-sigar.h"
 
+#ifdef WIN32
+#define snprintf _snprintf
+#endif
+
 /**
  * push the converted sigar_net_address_t as string on the stack
  */

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -92,6 +92,8 @@ static int lua_sigar_new(lua_State *L) {
 		lua_setfield(L, -2, "disk");
 		lua_pushcfunction(L, lua_sigar_who_get);
 		lua_setfield(L, -2, "who");
+		lua_pushcfunction(L, lua_sigar_load_get);
+		lua_setfield(L, -2, "load");
 		lua_pushcfunction(L, lua_sigar_netifs_get);
 		lua_setfield(L, -2, "netifs");
 		lua_pushcfunction(L, lua_sigar_proc_get);

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -36,6 +36,7 @@
 #include "sigar.h"
 #include "sigar_util.h"
 #include "sigar_os.h"
+#include "sigar_format.h"
 #include "lua-sigar.h"
 
 /**
@@ -43,40 +44,14 @@
  */
 int lua_sigar_push_address(lua_State *L, sigar_net_address_t *addr) {
 	char s[SIGAR_INET6_ADDRSTRLEN + 1];
-	size_t s_have = sizeof(s) - 1;
-	size_t s_need;
-
 	switch (addr->family) {
 	case SIGAR_AF_UNSPEC:
 		lua_pushnil(L);
 		return 1;
 	case SIGAR_AF_INET:
-		lua_pushfstring(L, "%d.%d.%d.%d",
-				(addr->addr.in >> 0) & 0xff,
-				(addr->addr.in >> 8) & 0xff,
-				(addr->addr.in >> 16) & 0xff,
-				(addr->addr.in >> 24) & 0xff);
-		return 1;
 	case SIGAR_AF_INET6:
-		inet_ntop(AF_INET6, &addr->addr.in6, s, INET6_ADDRSTRLEN);
-		lua_pushstring(L, s);
-		return 1;
 	case SIGAR_AF_LINK:
-		s_need = snprintf(s, s_have, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
-				addr->addr.mac[0],
-				addr->addr.mac[1],
-				addr->addr.mac[2],
-				addr->addr.mac[3],
-				addr->addr.mac[4],
-				addr->addr.mac[5],
-				addr->addr.mac[6],
-				addr->addr.mac[7]);
-
-		if (s_need > s_have) {
-			/* string is truncated, but written to s */
-			luaL_error(L, "can't convert MAC address string, not enough memory: %d need, %d available",
-					s_need, s_have);
-		}
+		sigar_net_address_to_string(NULL, addr, s);
 		lua_pushstring(L, s);
 		return 1;
 	}

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -138,8 +138,10 @@ static int lua_sigar_new(lua_State *L) {
 		lua_setfield(L, -2, "mem");
 		lua_pushcfunction(L, lua_sigar_swap_get);
 		lua_setfield(L, -2, "swap");
+#if 0
 		lua_pushcfunction(L, lua_sigar_version_get);
 		lua_setfield(L, -2, "version");
+#endif
 		lua_pushcfunction(L, lua_sigar_sysinfo_get);
 		lua_setfield(L, -2, "sysinfo");
 		lua_setfield(L, -2, "__index");
@@ -167,7 +169,7 @@ static void set_info (lua_State *L) {
 }
 
 
-static const struct luaL_reg sigarlib[] = {
+static const struct luaL_Reg sigarlib[] = {
 	{"new", lua_sigar_new},
 	{NULL, NULL}
 };

--- a/bindings/lua/sigar.c
+++ b/bindings/lua/sigar.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 
 #include "sigar.h"
+#include "sigar_os.h"
 #include "lua-sigar.h"
 
 /**

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 AC_CONFIG_MACRO_DIR([m4])
+m4_pattern_allow([^AC_DEFINE]) 
 
 AC_MSG_CHECKING([for os type ($host_os)])
 FRAMEWORK=

--- a/include/sigar_private.h
+++ b/include/sigar_private.h
@@ -72,6 +72,8 @@
 
 #if defined(WIN32)
 #   define SIGAR_INLINE __inline
+#elif defined(__clang__)
+#   define SIGAR_INLINE
 #elif defined(__GNUC__)
 #   define SIGAR_INLINE inline
 #else

--- a/include/sigar_private.h
+++ b/include/sigar_private.h
@@ -76,7 +76,8 @@
 #elif defined(__clang__)
 #   define SIGAR_INLINE
 #elif defined(__GNUC__)
-#   define SIGAR_INLINE inline
+/* inline disabled because of fedora22 gcc 5.1.1 */
+#   define SIGAR_INLINE
 #else
 #   define SIGAR_INLINE
 #endif

--- a/include/sigar_util.h
+++ b/include/sigar_util.h
@@ -17,6 +17,7 @@
 
 #ifndef SIGAR_UTIL_H
 #define SIGAR_UTIL_H
+#include "sigar_private.h"
 
 /* most of this is crap for dealing with linux /proc */
 #define UITOA_BUFFER_SIZE \

--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -3654,13 +3654,13 @@ int sigar_os_sys_info_get(sigar_t *sigar,
       return SIGAR_EPROC_NOENT;
     }
 
-    str = CFDictionaryGetValue(dict, _kCFSystemVersionProductNameKey);
+    str = CFDictionaryGetValue(dict, CFSTR(_kCFSystemVersionProductNameKey));
     CFStringGetCString(str, buf, sizeof(buf), kCFStringEncodingUTF8);
 
     SIGAR_SSTRCPY(sysinfo->name, "MacOSX");
     SIGAR_SSTRCPY(sysinfo->vendor_name, buf);
 
-    CFDictionaryGetValue(dict, _kCFSystemVersionProductVersionKey),
+    CFDictionaryGetValue(dict, CFSTR(_kCFSystemVersionProductVersionKey)),
     CFStringGetCString(str, buf, sizeof(buf), kCFStringEncodingUTF8);
 
     rv = sscanf(buf, "%d.%d.%d", &version_major, &version_minor, &version_fix);

--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -50,8 +50,6 @@
 #endif
 #include <mach-o/dyld.h>
 #define __OPENTRANSPORTPROVIDERS__
-#include <Gestalt.h>
-#include <CFString.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOBSD.h>
 #include <IOKit/IOKitLib.h>
@@ -3605,44 +3603,86 @@ int sigar_proc_port_get(sigar_t *sigar, int protocol,
 
 #endif
 
+#ifdef DARWIN
+
+/**
+ * OSX Stores the current version in these two plist files:
+ *    /System/Library/CoreServices/ServerVersion.plist
+ *    /System/Library/CoreServices/SystemVersion.plist
+ *
+ * We use the private CoreFoundations methods used by `/usr/bin/sw_vers`
+ * to access the contents of these files.
+ */
+
+extern CFDictionaryRef _CFCopyServerVersionDictionary();
+extern CFDictionaryRef _CFCopySystemVersionDictionary();
+
+#ifndef _kCFSystemVersionProductNameKey
+#define _kCFSystemVersionProductNameKey "ProductName"
+#endif
+
+#ifndef _kCFSystemVersionProductVersionKey
+#define _kCFSystemVersionProductVersionKey "ProductVersion"
+#endif
+
+#ifndef _kCFSystemVersionBuildVersionKey
+#define _kCFSystemVersionBuildVersionKey "ProductBuildVersion"
+#endif
+
+#endif
+
 int sigar_os_sys_info_get(sigar_t *sigar,
                           sigar_sys_info_t *sysinfo)
 {
 #ifdef DARWIN
     char *codename = NULL;
-    SInt32 version, version_major, version_minor, version_fix;
+    CFDictionaryRef dict = NULL;
+    CFStringRef str = NULL;
+    char buf[256];
+    int version_major = 0;
+    int version_minor = 0;
+    int version_fix = 0;
+    int rv;
+
+    dict = _CFCopyServerVersionDictionary();
+
+    if (dict == NULL) {
+      dict = _CFCopySystemVersionDictionary();
+    }
+
+    if (dict == NULL) {
+      return SIGAR_EPROC_NOENT;
+    }
+
+    str = CFDictionaryGetValue(dict, _kCFSystemVersionProductNameKey);
+    CFStringGetCString(str, buf, sizeof(buf), kCFStringEncodingUTF8);
 
     SIGAR_SSTRCPY(sysinfo->name, "MacOSX");
+    SIGAR_SSTRCPY(sysinfo->vendor_name, buf);
+
+    CFDictionaryGetValue(dict, _kCFSystemVersionProductVersionKey),
+    CFStringGetCString(str, buf, sizeof(buf), kCFStringEncodingUTF8);
+
+    rv = sscanf(buf, "%d.%d.%d", &version_major, &version_minor, &version_fix);
+
+    CFRelease(dict);
+
+    if (rv != 3) {
+      return SIGAR_EPERM_KMEM;
+    }
+
     SIGAR_SSTRCPY(sysinfo->vendor_name, "Mac OS X");
     SIGAR_SSTRCPY(sysinfo->vendor, "Apple");
-
-    if (Gestalt(gestaltSystemVersion, &version) == noErr) {
-        if (version >= 0x00001040) {
-            Gestalt('sys1' /*gestaltSystemVersionMajor*/, &version_major);
-            Gestalt('sys2' /*gestaltSystemVersionMinor*/, &version_minor);
-            Gestalt('sys3' /*gestaltSystemVersionBugFix*/, &version_fix);
-        }
-        else {
-            version_fix = version & 0xf;
-            version >>= 4;
-            version_minor = version & 0xf;
-            version >>= 4;
-            version_major = version - (version >> 4) * 6;
-        }
-    }
-    else {
-        return SIGAR_ENOTIMPL;
-    }
 
     snprintf(sysinfo->vendor_version,
              sizeof(sysinfo->vendor_version),
              "%d.%d",
-             (int)version_major, (int)version_minor);
+             version_major, version_minor);
 
     snprintf(sysinfo->version,
              sizeof(sysinfo->version),
              "%s.%d",
-             sysinfo->vendor_version, (int)version_fix);
+             sysinfo->vendor_version, version_fix);
 
     if (version_major == 10) {
         switch (version_minor) {
@@ -3663,6 +3703,9 @@ int sigar_os_sys_info_get(sigar_t *sigar,
             break;
           case 7:
             codename = "Lion";
+            break;
+          case 8:
+            codename = "Mountain Lion";
             break;
           default:
             codename = "Unknown";

--- a/src/os/darwin/sigar_os.h
+++ b/src/os/darwin/sigar_os.h
@@ -20,6 +20,7 @@
 #ifdef DARWIN
 #include <mach/port.h>
 #include <mach/host_info.h>
+#include <arpa/inet.h>
 #ifdef DARWIN_HAS_LIBPROC_H
 #include <mach-o/dyld.h>
 #include <libproc.h>

--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -1196,7 +1196,7 @@ static int get_iostat_sys(sigar_t *sigar,
         name += SSTRLEN(SIGAR_DEV_PREFIX); /* strip "/dev/" */
     }
 
-    while (!sigar_isdigit(*fsdev)) {
+    while (!sigar_isdigit(*fsdev) && *fsdev != '\0') {
         fsdev++;
     }
 

--- a/src/os/win32/sigar_os.h
+++ b/src/os/win32/sigar_os.h
@@ -667,6 +667,8 @@ int sigar_file_version_get(sigar_file_version_t *version,
                            char *name,
                            sigar_proc_env_t *infocb);
 
+const char* inet_ntop(int af, const void* src, char* dst, int cnt);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/os/win32/sigar_os.h
+++ b/src/os/win32/sigar_os.h
@@ -667,8 +667,6 @@ int sigar_file_version_get(sigar_file_version_t *version,
                            char *name,
                            sigar_proc_env_t *infocb);
 
-const char* inet_ntop(int af, const void* src, char* dst, int cnt);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/os/win32/win32_sigar.c
+++ b/src/os/win32/win32_sigar.c
@@ -3990,3 +3990,17 @@ int sigar_file_version_get(sigar_file_version_t *version,
     free(data);
     return status;
 }
+
+const char* inet_ntop(int af, const void* src, char* dst, int cnt) {
+  struct sockaddr_in srcaddr;
+  memset(&srcaddr, 0, sizeof(struct sockaddr_in));
+  memcpy(&(srcaddr.sin_addr), src, sizeof(srcaddr.sin_addr));
+  srcaddr.sin_family = af;
+  if (WSAAddressToString((struct sockaddr*) &srcaddr, sizeof(struct sockaddr_in), 0, dst, (LPDWORD) &cnt) != 0) {
+    DWORD rv = WSAGetLastError();
+    printf("WSAAddressToString() : %d\n",rv);
+    return NULL;
+  }
+  return dst;
+}
+

--- a/src/os/win32/win32_sigar.c
+++ b/src/os/win32/win32_sigar.c
@@ -3996,9 +3996,7 @@ const char* inet_ntop(int af, const void* src, char* dst, int cnt) {
   memset(&srcaddr, 0, sizeof(struct sockaddr_in));
   memcpy(&(srcaddr.sin_addr), src, sizeof(srcaddr.sin_addr));
   srcaddr.sin_family = af;
-  if (WSAAddressToString((struct sockaddr*) &srcaddr, sizeof(struct sockaddr_in), 0, dst, (LPDWORD) &cnt) != 0) {
-    DWORD rv = WSAGetLastError();
-    printf("WSAAddressToString() : %d\n",rv);
+  if (WSAAddressToString((struct sockaddr*) &srcaddr, sizeof(struct sockaddr_in), 0, dst, (LPDWORD) &cnt)) {
     return NULL;
   }
   return dst;

--- a/src/os/win32/win32_sigar.c
+++ b/src/os/win32/win32_sigar.c
@@ -3991,14 +3991,3 @@ int sigar_file_version_get(sigar_file_version_t *version,
     return status;
 }
 
-const char* inet_ntop(int af, const void* src, char* dst, int cnt) {
-  struct sockaddr_in srcaddr;
-  memset(&srcaddr, 0, sizeof(struct sockaddr_in));
-  memcpy(&(srcaddr.sin_addr), src, sizeof(srcaddr.sin_addr));
-  srcaddr.sin_family = af;
-  if (WSAAddressToString((struct sockaddr*) &srcaddr, sizeof(struct sockaddr_in), 0, dst, (LPDWORD) &cnt)) {
-    return NULL;
-  }
-  return dst;
-}
-

--- a/src/os/win32/win32_sigar.c
+++ b/src/os/win32/win32_sigar.c
@@ -3747,7 +3747,7 @@ int sigar_os_sys_info_get(sigar_t *sigar,
         }
     }
 
-    SIGAR_SSTRCPY(sysinfo->name, "Win32");
+    SIGAR_SSTRCPY(sysinfo->name, "Windows");
     SIGAR_SSTRCPY(sysinfo->vendor, "Microsoft");
     SIGAR_SSTRCPY(sysinfo->vendor_name, vendor_name);
     SIGAR_SSTRCPY(sysinfo->vendor_version, vendor_version);


### PR DESCRIPTION
Fixes an unbounded pointer traversal looking for a digit. Some linux kernels apparently do not return the partition number for IO devices, such as: `/dev/pts/0`, they just return `/dev/pts`