### PR TITLE
Fix build with glibc 2.28

### DIFF
--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -23,7 +23,12 @@
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/times.h>
+#include <sys/types.h>
 #include <sys/utsname.h>
+
+#ifdef __GNU_LIBRARY__
+#include <sys/sysmacros.h>
+#endif
 
 #include "sigar.h"
 #include "sigar_private.h"


### PR DESCRIPTION
This commit fixes the failure to build sigar against glibc 2.28, due to changes in location of the `major` and `minor` macros. See [the release notes](https://lists.gnu.org/archive/html/info-gnu/2018-08/msg00000.html) for more details.