### PR TITLE
Add support for aarch64

### DIFF
--- a/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchNameTask.java
+++ b/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchNameTask.java
@@ -75,7 +75,7 @@ public class ArchNameTask extends Task {
         if (ArchName.is64()) {
             getProject().setProperty("jni.arch64", "true");
             if (ArchLoader.IS_LINUX) {
-                if (!osArch.equals("ia64")) {
+                if (!osArch.equals("ia64") && !osArch.equals("aarch64")) {
                     getProject().setProperty("jni.gccm", "-m64");
                 }
             }

--- a/include/sigar_util.h
+++ b/include/sigar_util.h
@@ -75,11 +75,11 @@ int sigar_inet_ntoa(sigar_t *sigar,
 struct hostent *sigar_gethostbyname(const char *name,
                                     sigar_hostent_t *data);
 
-SIGAR_INLINE char *sigar_skip_line(char *buffer, int buflen);
+char *sigar_skip_line(char *buffer, int buflen);
 
-SIGAR_INLINE char *sigar_skip_token(char *p);
+char *sigar_skip_token(char *p);
 
-SIGAR_INLINE char *sigar_skip_multiple_token(char *p, int count);
+char *sigar_skip_multiple_token(char *p, int count);
 
 char *sigar_getword(char **line, char stop);
 

--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <sys/times.h>
 #include <sys/utsname.h>
+#include <sys/sysmacros.h>
 
 #include "sigar.h"
 #include "sigar_private.h"

--- a/src/sigar_util.c
+++ b/src/sigar_util.c
@@ -31,7 +31,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 
-SIGAR_INLINE char *sigar_uitoa(char *buf, unsigned int n, int *len)
+char *sigar_uitoa(char *buf, unsigned int n, int *len)
 {
     char *start = buf + UITOA_BUFFER_SIZE - 1;
 
@@ -46,7 +46,7 @@ SIGAR_INLINE char *sigar_uitoa(char *buf, unsigned int n, int *len)
     return start;
 }
 
-SIGAR_INLINE char *sigar_skip_line(char *buffer, int buflen)
+char *sigar_skip_line(char *buffer, int buflen)
 {
     char *ptr = buflen ?
         (char *)memchr(buffer, '\n', buflen) : /* bleh */
@@ -54,14 +54,14 @@ SIGAR_INLINE char *sigar_skip_line(char *buffer, int buflen)
     return ++ptr;
 }
 
-SIGAR_INLINE char *sigar_skip_token(char *p)
+char *sigar_skip_token(char *p)
 {
     while (sigar_isspace(*p)) p++;
     while (*p && !sigar_isspace(*p)) p++;
     return p;
 }
 
-SIGAR_INLINE char *sigar_skip_multiple_token(char *p, int count)
+char *sigar_skip_multiple_token(char *p, int count)
 {
     int i;
     


### PR DESCRIPTION
Add support in Sigar to build on aarch64.
- Updated ArchNameTask.java and linux_sigar.c to build on aarch64.
- Updated sigar_util.c and sigar_util.h to remove "undefined symbol: sigar_skip_token" error.