### PR TITLE
Add loongarch64 support

### DIFF
--- a/bindings/java/hyperic_jni/jni-build.xml
+++ b/bindings/java/hyperic_jni/jni-build.xml
@@ -323,7 +323,8 @@
       <compiler name="gcc" debug="${jni.debug}" if="linux">
         <compilerarg value="-O2" if="jni.optim"/>
         <compilerarg value="-g" if="jni.debug"/>
-        <compilerarg value="-Wall"/>
+	<compilerarg value="-Wall"/>
+	<compilerarg value="-fgnu89-inline"/>
         <compilerarg value="-Werror" if="jni.werror"/>
         <compilerarg value="${jni.gccm}" if="jni.gccm"/>
         <defineset>

--- a/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchNameTask.java
+++ b/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchNameTask.java
@@ -75,7 +75,7 @@ public class ArchNameTask extends Task {
         if (ArchName.is64()) {
             getProject().setProperty("jni.arch64", "true");
             if (ArchLoader.IS_LINUX) {
-                if (!osArch.equals("ia64")) {
+                if (!osArch.equals("ia64") && !osArch.equals("loongarch64") ) {
                     getProject().setProperty("jni.gccm", "-m64");
                 }
             }

--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -30,6 +30,8 @@
 #include "sigar_util.h"
 #include "sigar_os.h"
 
+#include <sys/sysmacros.h>
+
 #define pageshift(x) ((x) << sigar->pagesize)
 
 #define PROC_MEMINFO PROC_FS_ROOT "meminfo"


### PR DESCRIPTION
LoongArch is a risc architecture, like RISCV. This PR is used to support LoongArch.